### PR TITLE
adding ability to suspend and activate a customer

### DIFF
--- a/service/common/enums.py
+++ b/service/common/enums.py
@@ -1,0 +1,26 @@
+from enum import Enum
+
+
+class CustomerStatus(Enum):
+    """Enum representing the status of a Customer"""
+    ACTIVE = 'ACTIVE'
+    SUSPENDED = 'SUSPENDED'
+
+    def __str__(self):
+        """Returns the string representation of the CustomerStatus"""
+        return self.value
+
+    @classmethod
+    def from_string(cls, label: str):
+        """Converts a string to a CustomerStatus"""
+        if not label:
+            return None
+        try:
+            return cls[label.upper()]
+        except KeyError as exc:
+            raise ValueError(f'Invalid CustomerStatus: {label}') from exc
+
+    @classmethod
+    def string_equals(cls, label, other):
+        """Compares a string to a CustomerStatus"""
+        return cls.from_string(label) == other

--- a/service/common/enums.py
+++ b/service/common/enums.py
@@ -21,6 +21,6 @@ class CustomerStatus(Enum):
             raise ValueError(f'Invalid CustomerStatus: {label}') from exc
 
     @classmethod
-    def string_equals(cls, label, other):
+    def string_equals(cls, label: str, other: "CustomerStatus"):
         """Compares a string to a CustomerStatus"""
         return cls.from_string(label) == other

--- a/service/routes.py
+++ b/service/routes.py
@@ -207,12 +207,6 @@ def suspend_customer(customer_id):
             status.HTTP_404_NOT_FOUND,
             f'Customer with id {customer_id} does not exist'
         )
-    except SQLAlchemyError as sql_error:
-        app.logger.error(f'Failed to suspend customer with id {customer_id}: {str(sql_error)}')
-        abort(
-            status.HTTP_400_BAD_REQUEST,
-            f'Failed to suspend customer with id {customer_id}'
-        )
 
     app.logger.info(f"Customer with id [{customer_id}] suspend complete.")
     return (
@@ -242,12 +236,6 @@ def activate_customer(customer_id):
         abort(
             status.HTTP_404_NOT_FOUND,
             f'Customer with id {customer_id} does not exist'
-        )
-    except SQLAlchemyError as sql_error:
-        app.logger.error(f'Failed to activate customer with id {customer_id}: {str(sql_error)}')
-        abort(
-            status.HTTP_400_BAD_REQUEST,
-            f'Failed to activate customer with id {customer_id}'
         )
 
     app.logger.info(f"Customer with id [{customer_id}] activated.")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,3 @@
+""" importing for tests """
+
 from tests import factories

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -18,6 +18,7 @@ Test Factory to make fake objects for testing
 
 import factory
 from service.common.constants import PASSWORD_MAX_LEN
+from service.common.enums import CustomerStatus
 from service.models import Customer
 
 
@@ -34,3 +35,4 @@ class CustomerFactory(factory.Factory):
     last_name = factory.Faker("last_name")
     email = factory.Faker("email")
     password = factory.Faker("pystr", max_chars=PASSWORD_MAX_LEN)
+    status = CustomerStatus.ACTIVE

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,8 +2,10 @@
 Test file for common module code
 """
 
+
 import unittest
 from service.common.enums import CustomerStatus
+
 
 class TestCommon(unittest.TestCase):
     """ Test cases for Common module """
@@ -20,7 +22,6 @@ class TestCommon(unittest.TestCase):
         self.assertEqual(str(CustomerStatus.SUSPENDED), "SUSPENDED")
         self.assertEqual(CustomerStatus.ACTIVE, CustomerStatus.from_string("ACTIVE"))
         self.assertEqual(CustomerStatus.SUSPENDED, CustomerStatus.from_string("SUSPENDED"))
-
 
     ######################################################################
     #  S A D  T E S T   C A S E S

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,34 @@
+"""
+Test file for common module code
+"""
+
+import unittest
+from service.common.enums import CustomerStatus
+
+class TestCommon(unittest.TestCase):
+    """ Test cases for Common module """
+
+    ######################################################################
+    #  H A P P Y  T E S T   C A S E S
+    ######################################################################
+
+    def test_customer_status(self):
+        """ Test for customer status """
+        self.assertTrue(CustomerStatus.string_equals("ACTIVE", CustomerStatus.ACTIVE))
+        self.assertTrue(CustomerStatus.string_equals("SUSPENDED", CustomerStatus.SUSPENDED))
+        self.assertEqual(str(CustomerStatus.ACTIVE), "ACTIVE")
+        self.assertEqual(str(CustomerStatus.SUSPENDED), "SUSPENDED")
+        self.assertEqual(CustomerStatus.ACTIVE, CustomerStatus.from_string("ACTIVE"))
+        self.assertEqual(CustomerStatus.SUSPENDED, CustomerStatus.from_string("SUSPENDED"))
+
+
+    ######################################################################
+    #  S A D  T E S T   C A S E S
+    ######################################################################
+
+    def test_customer_status_bad(self):
+        """Sad tests for customer status"""
+
+        self.assertFalse(CustomerStatus.string_equals("ACTIVE", CustomerStatus.SUSPENDED))
+        self.assertFalse(CustomerStatus.string_equals("SUSPENDED", CustomerStatus.ACTIVE))
+        self.assertRaises(ValueError, CustomerStatus.from_string, "BAD")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,6 +5,7 @@ Test cases for Customer Model
 import logging
 import unittest
 from tests.factories import CustomerFactory
+from service.common.enums import CustomerStatus
 from service.models import Customer, db
 
 ######################################################################
@@ -128,7 +129,8 @@ class TestCustomer(unittest.TestCase):
             'first_name': 'John',
             'last_name': 'Smith',
             'email': 'johnsmith@johnsmith.com',
-            'password': 'johnsmith123'
+            'password': 'johnsmith123',
+            'status': CustomerStatus.ACTIVE.value
         }
 
         customer = self.create_customer()


### PR DESCRIPTION
Changes to the Customer model:
- added "status" field
    - type is `enum` which represents a fixed set of options
    - currently this field represents either "ACTIVE" or "SUSPENDED" but can be altered later to include additional customer states

Changes to routes.py
- added `customers/{id}/suspend` action route which sets the customer status to suspended
- added `customers/{id}/activate` action route which sets the customer status to active